### PR TITLE
fix: fzfに--ansiオプションを追加してghq選択画面の色を表示

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -127,7 +127,7 @@ widget::ghq::source() {
 }
 widget::ghq::select() {
     local root="$(ghq root)"
-    widget::ghq::source | fzf --exit-0 --preview="ls -laTp ${(q)root}/{2} | tail -n+4 | awk '{print \$9\"/\"\$6\"/\"\$7 \" \" \$10}'" --preview-window="right:60%" | cut -d' ' -f2-
+    widget::ghq::source | fzf --ansi --exit-0 --preview="ls -laTp ${(q)root}/{2} | tail -n+4 | awk '{print \$9\"/\"\$6\"/\"\$7 \" \" \$10}'" --preview-window="right:60%" | cut -d' ' -f2-
 }
 widget::ghq::dir() {
     local selected="$(widget::ghq::select)"


### PR DESCRIPTION
## Summary
- `Ctrl+G` のghqリポジトリ選択画面で色が正しく表示されるように修正
- fzfに `--ansi` オプションを追加

## 原因
fzfはデフォルトでANSIエスケープシーケンスをそのままテキストとして表示するため、`--ansi`オプションが必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)