### PR TITLE
fix: ghqアイコンをASCII文字に変更し、tmuxセッション処理を改善

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -111,7 +111,7 @@ widget::history() {
 }
 
 widget::ghq::source() {
-    local session color icon green=$'\e[32m' blue=$'\e[34m' reset=$'\e[m' checked=$'\uf631' unchecked=$'\uf630'
+    local session color icon green=$'\e[32m' blue=$'\e[34m' reset=$'\e[m' checked='*' unchecked='-'
     local sessions=($(tmux list-sessions -F "#S" 2>/dev/null))
 
     ghq list | sort | while read -r repo; do
@@ -147,7 +147,7 @@ widget::ghq::session() {
     fi
 
     local repo_dir="$(ghq list --exact --full-path "$selected")"
-    local session_name="${selected//[:. ]/-}"
+    local session_name="${selected##*/}"
 
     if [ -z "$TMUX" ]; then
         BUFFER="tmux new-session -A -s ${(q)session_name} -c ${(q)repo_dir}"
@@ -156,7 +156,8 @@ widget::ghq::session() {
         BUFFER="cd ${(q)repo_dir}"
         zle accept-line
     else
-        tmux new-session -d -s "$session_name" -c "$repo_dir" 2>/dev/null
+        tmux has-session -t "$session_name" 2>/dev/null || \
+            tmux new-session -d -s "$session_name" -c "$repo_dir"
         tmux switch-client -t "$session_name"
     fi
     zle -R -c # refresh screen


### PR DESCRIPTION
## Summary
- Nerd Fontsアイコン (`\uf631`, `\uf630`) を ASCII文字 (`*`, `-`) に変更
  - tmux内での文字化け対策
- session_nameをリポジトリ名のみに変更（パス全体ではなく）
- `tmux has-session` で既存セッション確認を追加

## 表示結果
- `* リポジトリ名` (緑色) = tmuxセッションあり
- `- リポジトリ名` (青色) = tmuxセッションなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)