### PR TITLE
fix: ghqセッション名からエスケープシーケンスを除去

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -122,7 +122,7 @@ widget::ghq::source() {
             color="$green"
             icon="$checked"
         fi
-        printf "$color$icon %s$reset\n" "$repo"
+        printf "$color$icon$reset %s\n" "$repo"
     done
 }
 widget::ghq::select() {


### PR DESCRIPTION
## Summary
- tmuxセッション名に `\033[m` が含まれる問題を修正
- resetコード (`$reset`) をアイコン直後に移動

## 原因
`printf "$color$icon %s$reset\n"` で `$reset` がリポジトリ名の後に付いていたため、`cut` で取り出した結果にエスケープシーケンスが含まれていた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)