### PR TITLE
fix: ghqセッション判定ロジックをセッション作成と一致させる

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -115,7 +115,7 @@ widget::ghq::source() {
     local sessions=($(tmux list-sessions -F "#S" 2>/dev/null))
 
     ghq list | sort | while read -r repo; do
-        session="${repo//[:. ]/-}"
+        session="${repo##*/}"
         color="$blue"
         icon="$unchecked"
         if (( ${+sessions[(r)$session]} )); then


### PR DESCRIPTION
## Summary
- セッション判定時のロジックをセッション作成時と一致させる
- `session="${repo##*/}"` でリポジトリ名のみを使用

## 原因
判定時は `github-com/user/repo` 形式、作成時は `repo` のみだったため、マッチしていなかった。

🤖 Generated with [Claude Code](https://claude.com/claude-code)